### PR TITLE
Release/0.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Switch Timer Card
 
-[![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg)](https://github.com/hacs/integration)
-[![Version](https://img.shields.io/github/v/release/joseluis9595/lovelace-switch-timer-card)](#)
+[![Buy me a beer](https://img.shields.io/badge/Support-Buy%20me%20a%20beer-fdd734?logo=buy-me-a-coffee)](https://www.buymeacoffee.com/joseluis9595)
 [![Last commit](https://img.shields.io/github/last-commit/joseluis9595/lovelace-switch-timer-card)](#)
 ![Downloads](https://img.shields.io/github/downloads/joseluis9595/lovelace-switch-timer-card/total)
+[![Version](https://img.shields.io/github/v/release/joseluis9595/lovelace-switch-timer-card)](#)
 
 Switch Timer Card is a custom Lovelace card for Home Assistant that provides a user-friendly interface to control a switch entity with added timer functionality. This card allows you to turn a switch ON or OFF and set a timer to automatically turn it off after a specified duration. It also features a collapsible design for a neat and organized UI.
 
@@ -11,39 +11,57 @@ Switch Timer Card is a custom Lovelace card for Home Assistant that provides a u
 https://github.com/joseluis9595/lovelace-switch-timer-card/assets/29345499/b9f451e9-46b8-4d59-a675-03b827574ff8
 
 
-## Installation
+<br>
 
-### Installation using HACS
+[**Installation**](#-installation) • [**Usage/Instructions**](#-usageinstructions) • [**Configuration**](#%EF%B8%8F-configuration) • [**Dashboard adjustements**](#%EF%B8%8F-dashboard-adjustements) • [**Example configurations**](#-example-configurations) • [**Help**](#-help) • [**Donate**](#-donate)
 
-1. If you haven't already, install [HACS](https://hacs.xyz/) - Home Assistant Community Store.
+<br>
 
-2. Open HACS and navigate to "Frontend."
 
-3. Add this repo as custom repository.
+## 🚀 Installation
 
-4. Click on the "+ Explore & Download Repositories" button.
+<details open>
+  <summary>HACS manual configuration</summary>
 
-5. Search for "Switch Timer Card" and click "Install" on the repository card.
+<br>
 
-### Manual Installation
+1. Go to HACS in Home Assistant.
+2. On the top right, click "Custom repositories".
+3. Enter the repository URL: https://github.com/joseluis9595/lovelace-switch-timer-card.git
+4. Search for "Switch Timer Card".
+5. Click Install!
 
-1. Download the `switch-timer-card.js` file from the [GitHub repository](https://github.com/joseluis9595/lovelace-switch-timer-card).
+</details>
 
-2. Upload the file to your Home Assistant configuration directory under `www/switch-timer-card.js`.
+<details>
+  <summary>Manual installation without HACS</summary>
 
-3. Add the following code to your Lovelace configuration to load the card:
+<br>
 
-```yaml
-resources:
-  - url: /local/switch-timer-card.js
-    type: module
-```
+1. Download [switch-timer-card.js](https://github.com/joseluis9595/lovelace-switch-timer-card/releases/latest/download/switch-timer-card.js) from the latest release.
+2. Move this file to home assistant's `<config>/www` folder.
+3. In home assistant, go to `Settings > Dashboards`.
+4. On the top right corner, click `Resources`.
+5. Add a new resource with the following:
+   - **URL**: `/local/switch-timer-card.js`
+   - **Resource type**: JavaScript module
+6. Go to your dashboard, refresh your page and add your new switch-timer-card!
 
-## Usage/Instructions
+</details>
+
+<br>
+
+---
+
+<br>
+
+## 📖 Usage/Instructions
 
 Before using the Switch Timer Card, you need to create a Timer Helper in Home Assistant. Follow these steps to set it up:
 
 1. Open your Home Assistant Configuration and navigate to "Configuration" > "Helpers."
+
+[![Open your Home Assistant instance and show your helper entities.](https://my.home-assistant.io/badges/helpers.svg)](https://my.home-assistant.io/redirect/helpers/)
 
 2. Click the "+ Add Helper" button.
 
@@ -68,3 +86,65 @@ title: Title of the card
 
 - `title` (optional): You can specify a title for the card if desired.
 
+<br>
+
+---
+
+<br>
+
+## ⚙️ Configuration
+
+<br>
+
+---
+
+<br>
+
+## 📚 Example Configurations
+
+<img width="514" height="166" alt="example_configuration" src="https://github.com/user-attachments/assets/48e83e78-d898-4f61-87df-cef1578f6f62" />
+
+
+```yaml
+type: custom:switch-timer-card
+title: Room radiator
+switch_entity: switch.radiator
+timer_entity: timer.test_timer
+buttons:
+  - minutes: 30
+  - minutes: 60
+  - hours: 1
+    minutes: 30
+```
+
+<br>
+
+---
+
+<br>
+
+## 💬 Help
+
+Need help using `switch-timer-card`, have ideas, or found a bug? Here's how you can reach out:
+
+- **🐛 Found a bug or have a feature request?**<br>
+  [Open an issue on GitHub](https://github.com/joseluis9595/lovelace-switch-timer-card/issues) so we can track and fix it.
+
+- **💬 Have questions, want to share feedback, or just chat?**<br>
+  Start [a discussion on GitHub](https://github.com/joseluis9595/lovelace-switch-timer-card/discussions).
+
+Your feedback helps make switch-timer-card better for everyone. Don’t hesitate to reach out!
+
+<br>
+
+---
+
+<br>
+
+## 🍻 Donate
+
+If you enjoy using `switch-timer-card` and want to support its continued development, consider buying me a coffee (or a beer 🍺), or becoming a GitHub Sponsor!
+
+[![Buy Me A Coffee](https://img.shields.io/badge/Buy_Me_a_Beer-fdd734?&logo=buy-me-a-coffee&logoColor=black&style=for-the-badge)](https://www.buymeacoffee.com/joseluis9595) [![GitHub Sponsors](https://img.shields.io/badge/GitHub_Sponsors-30363d?style=for-the-badge&logo=github&logoColor=white)](https://github.com/sponsors/joseluis9595)
+
+Your support means a lot and helps keep the project alive and growing. Thank you! 🙌

--- a/README.md
+++ b/README.md
@@ -7,16 +7,13 @@
 
 Switch Timer Card is a custom Lovelace card for Home Assistant that provides a user-friendly interface to control a switch entity with added timer functionality. This card allows you to turn a switch ON or OFF and set a timer to automatically turn it off after a specified duration. It also features a collapsible design for a neat and organized UI.
 
-
 https://github.com/joseluis9595/lovelace-switch-timer-card/assets/29345499/b9f451e9-46b8-4d59-a675-03b827574ff8
-
 
 <br>
 
 [**Installation**](#-installation) • [**Usage/Instructions**](#-usageinstructions) • [**Configuration**](#%EF%B8%8F-configuration) • [**Dashboard adjustements**](#%EF%B8%8F-dashboard-adjustements) • [**Example configurations**](#-example-configurations) • [**Help**](#-help) • [**Donate**](#-donate)
 
 <br>
-
 
 ## 🚀 Installation
 
@@ -94,6 +91,24 @@ title: Title of the card
 
 ## ⚙️ Configuration
 
+| Name            | Type                | Default    | Description                                                                         |
+| --------------- | ------------------- | ---------- | ----------------------------------------------------------------------------------- |
+| `switch_entity` | string              | `Required` | Entity ID of the switch you want to control.                                        |
+| `timer_entity`  | string              | `Required` | Entity ID of the timer helper used for this card.                                   |
+| `title`         | string              | -          | Optional title for the card. Will use the `switch_entity` friendly name by default. |
+| `buttons`       | [Button](#button)[] | -          | Customizable array of buttons with different time lengths for the timer.            |
+
+### Button
+
+Configuration for each button in `switch-timer-card`. You can configure the length of time with which the timer will start when pressing each button, plus manually configuring the text to display in the button if needed.
+
+| Name      | Type   | Default | Description                                                       |
+| --------- | ------ | ------- | ----------------------------------------------------------------- |
+| `seconds` | number | -       | Seconds to add to the timer.                                      |
+| `minutes` | number | -       | Minutes to add to the timer.                                      |
+| `hours`   | number | -       | Hours to add to the timer.                                        |
+| `text`    | number | -       | Optional text to override the auto-generated human readable time. |
+
 <br>
 
 ---
@@ -103,7 +118,6 @@ title: Title of the card
 ## 📚 Example Configurations
 
 <img width="514" height="166" alt="example_configuration" src="https://github.com/user-attachments/assets/48e83e78-d898-4f61-87df-cef1578f6f62" />
-
 
 ```yaml
 type: custom:switch-timer-card

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ https://github.com/joseluis9595/lovelace-switch-timer-card/assets/29345499/b9f45
 
 <br>
 
-[**Installation**](#-installation) • [**Usage/Instructions**](#-usageinstructions) • [**Configuration**](#%EF%B8%8F-configuration) • [**Dashboard adjustements**](#%EF%B8%8F-dashboard-adjustements) • [**Example configurations**](#-example-configurations) • [**Help**](#-help) • [**Donate**](#-donate)
+[**Installation**](#-installation) • [**Usage/Instructions**](#-usageinstructions) • [**Configuration**](#%EF%B8%8F-configuration) • [**Example configurations**](#-example-configurations) • [**Help**](#-help) • [**Donate**](#-donate)
 
 <br>
 

--- a/bun.lock
+++ b/bun.lock
@@ -14,7 +14,7 @@
         "@eslint/js": "^9.27.0",
         "@open-wc/testing": "^4.0.0",
         "@testing-library/dom": "^10.4.0",
-        "@testing-library/jest-dom": "^6.6.3",
+        "@testing-library/jest-dom": "^6.7.0",
         "@types/bun": "latest",
         "@typescript-eslint/eslint-plugin": "^8.32.1",
         "@typescript-eslint/parser": "^8.32.1",
@@ -209,7 +209,7 @@
 
     "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
 
-    "@testing-library/jest-dom": ["@testing-library/jest-dom@6.6.4", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "lodash": "^4.17.21", "picocolors": "^1.1.1", "redent": "^3.0.0" } }, "sha512-xDXgLjVunjHqczScfkCJ9iyjdNOVHvvCdqHSSxwM9L0l/wHkTRum67SDc020uAlCoqktJplgO2AAQeLP1wgqDQ=="],
+    "@testing-library/jest-dom": ["@testing-library/jest-dom@6.7.0", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "picocolors": "^1.1.1", "redent": "^3.0.0" } }, "sha512-RI2e97YZ7MRa+vxP4UUnMuMFL2buSsf0ollxUbTgrbPLKhMn8KVTx7raS6DYjC7v1NDVrioOvaShxsguLNISCA=="],
 
     "@types/accepts": ["@types/accepts@1.3.7", "", { "dependencies": { "@types/node": "*" } }, "sha512-Pay9fq2lM2wXPWbteBsRAGiWH2hig4ZE2asK+mm7kUzlxRTfL961rj89I6zV/E3PcIkDqyuBEcMxFT7rccugeQ=="],
 
@@ -668,8 +668,6 @@
     "lit-html": ["lit-html@3.3.1", "", { "dependencies": { "@types/trusted-types": "^2.0.2" } }, "sha512-S9hbyDu/vs1qNrithiNyeyv64c9yqiW9l+DBgI18fL+MTvOtWoFR0FWiyq1TxaYef5wNlpEmzlXoBlZEO+WjoA=="],
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
-
-    "lodash": ["lodash@4.17.21", "", {}, "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="],
 
     "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switch-timer-card",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "author": "Jose Alvarez Quiroga <joseluisalvquiroga@gmail.com>",
   "repository": "git@github.com:joseluis9595/lovelace-switch-timer-card.git",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@eslint/js": "^9.27.0",
     "@open-wc/testing": "^4.0.0",
     "@testing-library/dom": "^10.4.0",
-    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/jest-dom": "^6.7.0",
     "@types/bun": "latest",
     "@typescript-eslint/eslint-plugin": "^8.32.1",
     "@typescript-eslint/parser": "^8.32.1",

--- a/src/__tests__/switch-timer-card.test.ts
+++ b/src/__tests__/switch-timer-card.test.ts
@@ -223,11 +223,6 @@ describe('SwitchTimerCard', () => {
     it('should have static styles', () => {
       expect(SwitchTimerCard.styles).toBeDefined();
     });
-
-    it('should have config element method', () => {
-      expect(SwitchTimerCard.getConfigElement).toBeDefined();
-      expect(typeof SwitchTimerCard.getConfigElement).toBe('function');
-    });
   });
 
   describe('Local Storage', () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,18 @@
+export interface SwitchTimerCardButton {
+  seconds?: number;
+  minutes?: number;
+  hours?: number;
+}
+
 export interface SwitchTimerCardConfig {
-  type: string;
-  name?: string;
+  title?: string;
   switch_entity: string;
   timer_entity: string;
-  title?: string;
+  buttons?: SwitchTimerCardButton[];
 }
+
+export const DEFAULT_CONFIG: SwitchTimerCardConfig = {
+  switch_entity: '',
+  timer_entity: '',
+  buttons: [{ minutes: 30 }, { minutes: 60 }, { minutes: 90 }],
+};

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,7 @@ export interface SwitchTimerCardButton {
   seconds?: number;
   minutes?: number;
   hours?: number;
+  text?: string;
 }
 
 export interface SwitchTimerCardConfig {

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -193,15 +193,16 @@ const CARD_STYLES = css`
     appearance: none;
     flex: 1;
     height: 6px;
+    border-radius: 99px;
   }
   .progress-bar::-webkit-progress-bar {
     position: relative;
-    border-radius: 6px;
+    border-radius: 99px;
     background-color: rgba(var(--rgb-info-color), 0.2);
   }
   .progress-bar::-webkit-progress-value {
     background-color: var(--info-color);
-    border-radius: 6px;
+    border-radius: 99px;
   }
 `;
 

--- a/src/switch-timer-card.ts
+++ b/src/switch-timer-card.ts
@@ -330,9 +330,13 @@ export class SwitchTimerCard extends LitElement {
     return `switch-timer-card_${this._unique_id}`;
   }
 
-  toggleMinimized() {
-    this._minimized = !this._minimized;
+  setMinimized(minimized: boolean) {
+    this._minimized = minimized;
     localStorage.setItem(this.getLocalStorageKey(), this._minimized.toString());
+  }
+
+  toggleMinimized() {
+    this.setMinimized(!this._minimized);
   }
 
   open_more_info(entity_id) {

--- a/src/switch-timer-card.ts
+++ b/src/switch-timer-card.ts
@@ -287,7 +287,7 @@ export class SwitchTimerCard extends LitElement {
                           class="timer-button"
                           @click=${() =>
                             this.buttonClicked(timerEntity, seconds)}>
-                          ${humanReadableTime(seconds)}
+                          ${button.text || humanReadableTime(seconds)}
                         </button>
                       `;
                     })}

--- a/src/switch-timer-card.ts
+++ b/src/switch-timer-card.ts
@@ -1,5 +1,5 @@
 import { html, LitElement, PropertyValues } from 'lit';
-import { customElement, state } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 import { version } from '../package.json';
 import { getDefaultStyles } from './styles';
 import { HomeAssistant } from 'custom-card-helpers';
@@ -26,7 +26,7 @@ window.customCards.push({
 
 @customElement('switch-timer-card')
 export class SwitchTimerCard extends LitElement {
-  @state() protected hass!: HomeAssistant;
+  @property({ attribute: false }) public hass!: HomeAssistant;
   @state() private _config!: SwitchTimerCardConfig;
   @state() private _minimized = true;
   // TODO replace with hass `timer` service

--- a/src/switch-timer-card.ts
+++ b/src/switch-timer-card.ts
@@ -41,10 +41,6 @@ export class SwitchTimerCard extends LitElement {
       localStorage.getItem(this.getLocalStorageKey()) === 'true';
   }
 
-  static getConfigElement() {
-    return document.createElement('content-card-editor');
-  }
-
   setConfig(config) {
     if (!config.switch_entity) {
       throw new Error("You need to define param 'switch_entity'");
@@ -57,40 +53,42 @@ export class SwitchTimerCard extends LitElement {
     this._unique_id = `${config.timer_entity}_${config.switch_entity}_${window.location.href}`;
   }
 
-  // shouldUpdate(changedProps) {
-  //   if (!this._config) return false;
-  //   if (changedProps.has('_timeRemaining')) return true;
+  protected shouldUpdate(_changedProps: PropertyValues): boolean {
+    if (!this._config) return false;
+    if (_changedProps.has('_timeRemaining')) return true;
+    return super.shouldUpdate(_changedProps);
 
-  //   const hasChanged1 = hasConfigOrEntityChanged(
-  //     this,
-  //     this._config?.timer_entity,
-  //     changedProps,
-  //     false,
-  //   );
-  //   const hasChanged2 = hasConfigOrEntityChanged(
-  //     this,
-  //     this._config?.switch_entity,
-  //     changedProps,
-  //     false,
-  //   );
-  //   return hasChanged1 || hasChanged2;
-  // }
+    // const hasChanged1 = hasConfigOrEntityChanged(
+    //   this,
+    //   this._config?.timer_entity,
+    //   changedProps,
+    //   false,
+    // );
+    // const hasChanged2 = hasConfigOrEntityChanged(
+    //   this,
+    //   this._config?.switch_entity,
+    //   changedProps,
+    //   false,
+    // );
+    // return hasChanged1 || hasChanged2;
+  }
 
-  // updated(changedProps) {
-  //   super.updated(changedProps);
+  protected updated(changedProps: PropertyValues) {
+    super.updated(changedProps);
 
-  //   if (changedProps.has('hass')) {
-  //     const stateObj = this.hass?.states[this._config?.timer_entity];
-  //     const oldStateObj =
-  //       changedProps.get('hass')?.states[this._config?.timer_entity];
+    // Start a timer if the timer entity is changed (will also be triggered on the first render)
+    if (changedProps.has('hass')) {
+      const stateObj = this.hass?.states[this._config?.timer_entity];
+      const oldStateObj =
+        changedProps.get('hass')?.states[this._config?.timer_entity];
 
-  //     if (oldStateObj !== stateObj) {
-  //       this._startInterval(stateObj);
-  //     } else if (!stateObj) {
-  //       this._clearInterval();
-  //     }
-  //   }
-  // }
+      if (oldStateObj !== stateObj) {
+        this._startInterval(stateObj);
+      } else if (!stateObj) {
+        this._clearInterval();
+      }
+    }
+  }
 
   _startIconLongPressTimer(entity) {
     this._longPressed = false;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import { SwitchTimerCardButton } from './config';
+
 /**
  * @param number - The number to pad.
  * @returns A string representing the number padded with zeros.
@@ -7,15 +9,44 @@ const padNumber = (number: number) => {
 };
 
 /**
+ * @param seconds - The number of seconds to convert to a home assistant format string.
+ * @returns A string representing the number of seconds in the format of hh:mm:ss.
+ */
+export const homeAssistantFormatTime = (seconds: number) => {
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  const remainingSeconds = seconds % 60;
+  return `${padNumber(hours)}:${padNumber(minutes)}:${padNumber(remainingSeconds)}`;
+};
+
+/**
  * @param seconds - The number of seconds to convert to a human readable string.
- * @returns A string representing the number of seconds in the format of mm:ss.
  */
 export const humanReadableTime = (seconds: number) => {
-  if (!seconds) return '-';
-  if (seconds < 60) return seconds;
-  if (seconds < 60 * 60) {
-    return `${padNumber(seconds / 60)}:${padNumber(seconds % 60)}`;
+  const hours = Math.floor(seconds / 3600);
+  const minutes = Math.floor((seconds % 3600) / 60);
+  const remainingSeconds = seconds % 60;
+  let formattedTime = '';
+  if (hours > 0) {
+    formattedTime += `${hours}h `;
   }
-  // TODO calculate hours and siplay with human readable format
-  return `${padNumber(seconds / 60)}:${padNumber(seconds % 60)}`;
+  if (minutes > 0) {
+    formattedTime += `${minutes}m `;
+  }
+  if (remainingSeconds > 0) {
+    formattedTime += `${remainingSeconds}s`;
+  }
+  return formattedTime;
+};
+
+/**
+ * @param time - The time to parse.
+ * @returns The total number of seconds.
+ */
+export const convertCardConfigTimeToSeconds = (time: SwitchTimerCardButton) => {
+  let totalSeconds = 0;
+  if (time.hours) totalSeconds += time.hours * 60 * 60;
+  if (time.minutes) totalSeconds += time.minutes * 60;
+  if (time.seconds) totalSeconds += time.seconds;
+  return totalSeconds;
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
     "resolveJsonModule": true,
     "experimentalDecorators": true,
     "outDir": "dist",
-    "rootDir": "."
+    "rootDir": ".",
+    "useDefineForClassFields": false
   },
   "include": ["**/*.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## New `buttons` configuration

You can now fully customize the timer buttons to fit your needs.
- Choose how many buttons to display.
- Set the amount of time each button adds to the timer entity.

Configuration is straightforward. For example:

```yaml
type: custom:switch-timer-card
...
buttons:
  - minutes: 30
  - minutes: 60
  - hours: 1
    minutes: 30
```

<img width="514" height="166" alt="example_configuration" src="https://github.com/user-attachments/assets/e0ac802a-287b-4887-a8c6-d1157f0bfa31" />


<br />

---

#### All changes

- New `buttons` configuration (closes #3 )
- Fix issue where `switch-timer-card` would not update its UI state (closes #7 )
- Update README docs
- Update tests