### PR TITLE
Release/0.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switch-timer-card",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "author": "Jose Alvarez Quiroga <joseluisalvquiroga@gmail.com>",
   "repository": "git@github.com:joseluis9595/lovelace-switch-timer-card.git",
   "license": "MIT",

--- a/src/switch-timer-card.ts
+++ b/src/switch-timer-card.ts
@@ -309,21 +309,16 @@ export class SwitchTimerCard extends LitElement {
   }
 
   cancelButtonClicked(timerEntity) {
-    this.hass.callService('timer', 'finish', {
+    this.hass.callService('timer', 'cancel', {
       entity_id: timerEntity.entity_id,
     });
   }
 
-  toggleSwitch(switchEntity, state) {
-    if (state) {
-      this.hass.callService('switch', 'turn_on', {
-        entity_id: switchEntity.entity_id,
-      });
-    } else {
-      this.hass.callService('switch', 'turn_off', {
-        entity_id: switchEntity.entity_id,
-      });
-    }
+  toggleSwitch(switchEntity, turnOn) {
+    if (!switchEntity) return;
+    this.hass.callService('homeassistant', turnOn ? 'turn_on' : 'turn_off', {
+      entity_id: switchEntity.entity_id,
+    });
   }
 
   getLocalStorageKey() {


### PR DESCRIPTION
## Generic turn_on/turn_off service

The `switch-timer-card` no longer assumes its defined entity must be a switch. It now uses the generic Home Assistant `turn_on` / `turn_off` services, which allows it to work with any compatible entity type. This change is fully backwards-compatible with existing configurations

## Cancel button behaviour

The cancel button action has been updated to call `timer.cancel` instead of `timer.finish`, ensuring it follows the intended usage of the timer services more accurately.

<br/>

---

#### All changes

- Use generic `turn_on` / `turn_off` service instead of `switch.turn_on` / `switch.turn_off` respectively. Thanks @coolssor (closes #4 )
- Fix cancel button action, from `timer.finish` to `timer.cancel`. Once again, thanks @coolssor